### PR TITLE
Add commandline tool to download current firmware files directly from 8BitDo

### DIFF
--- a/8bitdo-firmware.py
+++ b/8bitdo-firmware.py
@@ -1,5 +1,8 @@
 #!/usr/bin/python3
 
+# (c) 2025 Florian 'floe' Echtler <floe@butterbrot.org>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 # based on https://ladis.cloud/blog/posts/firmware-update-8bitdo.html
 
 import requests,json,sys,os

--- a/8bitdo-firmware.py
+++ b/8bitdo-firmware.py
@@ -10,7 +10,7 @@ import urllib.request
 
 baseurl = "http://dl.8bitdo.com:8080"
 
-things = {}
+products = {}
 
 def halp():
     print("Usage: 8bitdo-firmware.py ...\n")
@@ -29,25 +29,25 @@ result = response.json()
 
 for item in result["list"]:
     num = item["type"]
-    if not num in things:
-        things[num] = []
-    things[num].append(item)
+    if not num in products:
+        products[num] = []
+    products[num].append(item)
 
 if sys.argv[1] == "-l":
 
     if len(sys.argv) == 2:
     
-        for num,item in things.items():
+        for num,item in products.items():
             print(str(num)+":\t"+item[0]["fileName"])
         exit(0)
 
     else:
 
         num = int(sys.argv[2])
-        if num not in things:
+        if num not in products:
             print("... device number not found.\n")
             exit(1)
-        fws = things[num]
+        fws = products[num]
 
         print("Firmware versions for "+fws[0]["fileName"]+" (#"+str(num)+"):\n")
 
@@ -64,7 +64,7 @@ if sys.argv[1] == "-f":
     num = int(sys.argv[2])
     ver = sys.argv[3]
 
-    fws = things[num]
+    fws = products[num]
 
     print("Fetching firmware "+ver+" for "+fws[0]["fileName"]+" (#"+str(num)+"):\n")
     for fw in fws:

--- a/8bitdo-firmware.py
+++ b/8bitdo-firmware.py
@@ -8,7 +8,10 @@ baseurl = "http://dl.8bitdo.com:8080"
 things = {}
 
 def halp():
-    print("Halp!")
+    print("Usage: 8bitdo-firmware.py ...\n")
+    print("\t-l\t\tlist all available devices")
+    print("\t-l [num]\tlist all firmware versions for device [num]")
+    print("\t-f [num] [ver]\tfetch firmware version [ver] for device [num]\n")
     exit(0)
 
 print("8BitDo Firmware Fetcher v0.0.1\n")
@@ -36,6 +39,9 @@ if sys.argv[1] == "-l":
     else:
 
         num = int(sys.argv[2])
+        if num not in things:
+            print("... device number not found.\n")
+            exit(1)
         fws = things[num]
 
         print("Firmware versions for "+fws[0]["fileName"]+" (#"+str(num)+"):\n")
@@ -62,5 +68,8 @@ if sys.argv[1] == "-f":
             file = os.path.basename(url)
             print("Downloading: "+url)
             urllib.request.urlretrieve(url,file)
-            print("Saved firmware to "+file)
+            print("Saved firmware to "+file+".\n")
             exit(0)
+
+    print("... version not found.\n")
+    exit(1)

--- a/8bitdo-firmware.py
+++ b/8bitdo-firmware.py
@@ -12,7 +12,7 @@ baseurl = "http://dl.8bitdo.com:8080"
 
 products = {}
 
-def halp():
+def help():
     print("Usage: 8bitdo-firmware.py ...\n")
     print("\t-l\t\tlist all available devices")
     print("\t-l [num]\tlist all firmware versions for device [num]")
@@ -22,7 +22,7 @@ def halp():
 print("8BitDo Firmware Fetcher v0.0.1\n")
 
 if len(sys.argv) == 1 or sys.argv[1] in [ "-?", "-h", "--help" ]:
-    halp()
+    help()
 
 response = requests.post(baseurl+"/firmware/select",headers={"Beta":"1"})
 result = response.json()
@@ -61,7 +61,7 @@ if sys.argv[1] == "-l":
 if sys.argv[1] == "-f":
 
     if len(sys.argv) != 4:
-        halp()
+        help()
 
     num = int(sys.argv[2])
     ver = sys.argv[3]

--- a/8bitdo-firmware.py
+++ b/8bitdo-firmware.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python3
 
+# based on https://ladis.cloud/blog/posts/firmware-update-8bitdo.html
+
 import requests,json,sys,os
 import urllib.request
 

--- a/8bitdo-firmware.py
+++ b/8bitdo-firmware.py
@@ -38,7 +38,7 @@ if sys.argv[1] == "-l":
     if len(sys.argv) == 2:
     
         for num,item in products.items():
-            print(str(num)+":\t"+item[0]["fileName"])
+            print(f"{num}:\t{item[0]["fileName"]}")
         exit(0)
 
     else:
@@ -49,12 +49,12 @@ if sys.argv[1] == "-l":
             exit(1)
         fws = products[num]
 
-        print("Firmware versions for "+fws[0]["fileName"]+" (#"+str(num)+"):\n")
+        print(f"Firmware versions for {fws[0]["fileName"]} (#{num}):\n")
 
         for fw in fws:
             ver = str(fw["version"])
             beta = " (beta)" if fw["beta"] != "" else ""
-            print(ver[0:4]+" (build "+ver[4:]+")"+beta)
+            print(f"{ver[0:4]} (build {ver[4:]})"+beta)
 
 if sys.argv[1] == "-f":
 
@@ -66,7 +66,7 @@ if sys.argv[1] == "-f":
 
     fws = products[num]
 
-    print("Fetching firmware "+ver+" for "+fws[0]["fileName"]+" (#"+str(num)+"):\n")
+    print(f"Fetching firmware {ver} for {fws[0]["fileName"]} (#{num}):\n")
     for fw in fws:
         if str(fw["version"]).startswith(ver):
             url = baseurl+fw["filePathName"]

--- a/8bitdo-firmware.py
+++ b/8bitdo-firmware.py
@@ -1,0 +1,42 @@
+#!/usr/bin/python3
+
+import requests,json,sys
+
+baseurl = "http://dl.8bitdo.com:8080"
+
+things = {}
+
+print("8BitDo Firmware Fetcher v0.0.1\n")
+
+if len(sys.argv) == 1 or sys.argv[1] in [ "-?", "-h", "--help" ]:
+    print("Halp!")
+    exit(0)
+
+response = requests.post(baseurl+"/firmware/select",headers={"Beta":"1"})
+result = response.json()
+
+for item in result["list"]:
+    num = item["type"]
+    if not num in things:
+        things[num] = []
+    things[num].append(item)
+
+if sys.argv[1] == "-l":
+
+    if len(sys.argv) == 2:
+    
+        for num,item in things.items():
+            print(str(num)+":\t"+item[0]["fileName"])
+        exit(0)
+
+    else:
+
+        num = int(sys.argv[2])
+        fws = things[num]
+
+        print("Firmware versions for "+fws[0]["fileName"]+" (#"+str(num)+"):\n")
+
+        for fw in fws:
+            ver = str(fw["version"])
+            beta = " (beta)" if fw["beta"] != "" else ""
+            print(ver[0:4]+"."+ver[4:]+beta)

--- a/8bitdo-firmware.py
+++ b/8bitdo-firmware.py
@@ -39,7 +39,6 @@ if sys.argv[1] == "-l":
     
         for num,item in products.items():
             print(f"{num}:\t{item[0]["fileName"]}")
-        exit(0)
 
     else:
 
@@ -55,6 +54,9 @@ if sys.argv[1] == "-l":
             ver = str(fw["version"])
             beta = " (beta)" if fw["beta"] != "" else ""
             print(f"{ver[0:4]} (build {ver[4:]})"+beta)
+
+    print("")
+    exit(0)
 
 if sys.argv[1] == "-f":
 

--- a/8bitdo-firmware.py
+++ b/8bitdo-firmware.py
@@ -1,16 +1,20 @@
 #!/usr/bin/python3
 
-import requests,json,sys
+import requests,json,sys,os
+import urllib.request
 
 baseurl = "http://dl.8bitdo.com:8080"
 
 things = {}
 
+def halp():
+    print("Halp!")
+    exit(0)
+
 print("8BitDo Firmware Fetcher v0.0.1\n")
 
 if len(sys.argv) == 1 or sys.argv[1] in [ "-?", "-h", "--help" ]:
-    print("Halp!")
-    exit(0)
+    halp()
 
 response = requests.post(baseurl+"/firmware/select",headers={"Beta":"1"})
 result = response.json()
@@ -39,4 +43,24 @@ if sys.argv[1] == "-l":
         for fw in fws:
             ver = str(fw["version"])
             beta = " (beta)" if fw["beta"] != "" else ""
-            print(ver[0:4]+"."+ver[4:]+beta)
+            print(ver[0:4]+" (build "+ver[4:]+")"+beta)
+
+if sys.argv[1] == "-f":
+
+    if len(sys.argv) != 4:
+        halp()
+
+    num = int(sys.argv[2])
+    ver = sys.argv[3]
+
+    fws = things[num]
+
+    print("Fetching firmware "+ver+" for "+fws[0]["fileName"]+" (#"+str(num)+"):\n")
+    for fw in fws:
+        if str(fw["version"]).startswith(ver):
+            url = baseurl+fw["filePathName"]
+            file = os.path.basename(url)
+            print("Downloading: "+url)
+            urllib.request.urlretrieve(url,file)
+            print("Saved firmware to "+file)
+            exit(0)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Firmware for 8Bitdo controllers
 
+_NOTE:_ sometime in 2020, 8BitDo stopped providing downloadable firmware files and switched to an opaque API.
+Some information is provided at https://ladis.cloud/blog/posts/firmware-update-8bitdo.html and firmware files 
+can now be downloaded using `8bitdo-firmware.py`.
+
 The `.dat` files can be applied using the `ebitdo-tool` binary in fwupd, or the
 generated `.cab` files can be installed using `gnome-software` or `fwupdmgr`.
 


### PR DESCRIPTION
Sometime in 2020, 8BitDo stopped providing downloadable firmware files and switched to an opaque API. Some information is provided at https://ladis.cloud/blog/posts/firmware-update-8bitdo.html and based on that blog post, firmware files can now be downloaded using `8bitdo-firmware.py`.